### PR TITLE
Release version 1.1.1-2

### DIFF
--- a/src/Acl/Acl.js
+++ b/src/Acl/Acl.js
@@ -36,6 +36,7 @@ class Acl {
       body: postModel
     }).catch(err => {
       console.warn(`Error saving ${resourceType}: `, err);
+      throw err;
     });
   };
 
@@ -45,6 +46,7 @@ class Acl {
       body: putModel
     }).catch(err => {
       console.warn(`Error saving ${resourceType}: `, err);
+      throw err;
     });
   };
 
@@ -54,6 +56,7 @@ class Acl {
       body: deleteModel
     }).catch(err => {
       console.log(`Error deleting ${resourceType}: `, err);
+      throw err;
     });
   };
 }

--- a/src/Ldap/Ldap.js
+++ b/src/Ldap/Ldap.js
@@ -59,7 +59,7 @@ class Ldap {
       search: { common_name: queryText }
     }).catch(err => {
       console.log("Error searching Ldap Data:", e.statusText);
-      throw e;
+      throw err;
     });
   };
 


### PR DESCRIPTION
When applications call the Acl or Ldap class for CRUD operations on the API, some of the methods are not throwing the corresponding errors.

Add throw error on all operations