### PR TITLE
FP-1822 : Token verify endpoint should receive the actual token

### DIFF
--- a/src/Database/WSSub.js
+++ b/src/Database/WSSub.js
@@ -322,7 +322,7 @@ class WSSub {
   checkConnection = () => {
     return fetch(`/token-verify/`, {
       method: "POST",
-      body: JSON.stringify({ token: "" })
+      body: JSON.stringify({ token: getToken() })
     })
       .then(res => {
         if (this.connectionState === CONNECTION.online) return;
@@ -352,9 +352,9 @@ class WSSub {
       .addSubscriberCallback(callback, _pattern)
       .addEventCallback(SUBSCRIBE, evt_callback, _pattern);
 
-      if(this.getState() === WebSocket.OPEN){
-        this.send(message);
-      }
+    if (this.getState() === WebSocket.OPEN) {
+      this.send(message);
+    }
   };
 
   /**


### PR DESCRIPTION
https://movai.atlassian.net/browse/FP-1822
We’re currently using the token-verify endpoint to check if backend is responding, but the token being sent is empty. This causes the backend to throw exceptions and log them internally, which is not expected.

Frontend apps should send the actual token to the token-verify endpoint or use other endpoint to check if the connection with the backend is alive.