### PR TITLE
Fix types of logs query parameter

### DIFF
--- a/src/api/RobotManager/Utils/Utils.ts
+++ b/src/api/RobotManager/Utils/Utils.ts
@@ -1,4 +1,4 @@
-import { LogTag } from "../../../models";
+import { LogLevel, LogTag, TimestampQuery } from "../../../models";
 import { SERVICE_LIST } from "../../Utils/constants";
 
 //========================================================================================
@@ -32,7 +32,7 @@ function getDateWithoutSeconds(date: number): number {
  */
 export function getRequestLevels(
   selectedLevels: Array<string>,
-  levelsList: Array<string> = []
+  levelsList: Array<LogLevel> = []
 ): string {
   if (
     Array.isArray(selectedLevels) &&
@@ -80,8 +80,8 @@ export function getRequestService(selectedService: Array<string>): string {
  * @returns {string} Request query param string for dates
  */
 export function getRequestDate(
-  selectedFromDate: number,
-  selectedToDate: number
+  selectedFromDate: TimestampQuery,
+  selectedToDate: TimestampQuery
 ): string {
   let res = "";
   try {

--- a/src/models/robot.ts
+++ b/src/models/robot.ts
@@ -75,12 +75,19 @@ export interface LogTag {
   key: string;
 }
 
+export interface LogLevel {
+  value: string;
+  label: string;
+}
+
+export type TimestampQuery = number | "";
+
 export interface LogQueryParam {
-  level: { selected: Array<string>; list: Array<string> };
+  level: { selected: Array<string>; list: Array<LogLevel> };
   service: { selected: Array<string> };
   tag: { selected: Array<LogTag> };
   searchMessage: string;
-  date: { from: number; to: number };
+  date: { from: TimestampQuery; to: TimestampQuery };
   robot: { selected: Array<string> };
   limit: number;
 }


### PR DESCRIPTION
- Fix types of LogQueryParam
  - level : level.list should be an array of objects
  - date : Date should also accept empty strings