### PR TITLE
FP-1949 : Update Refresh token method

### DIFF
--- a/src/api/Authentication/Authentication.ts
+++ b/src/api/Authentication/Authentication.ts
@@ -224,10 +224,12 @@ export default class Authentication {
 
   static refreshTokens = async (remember = false): Promise<boolean> => {
     const refreshToken = Authentication.getRefreshToken();
+    const accessToken = Authentication.getToken();
 
     const url = `/token-refresh/`;
     const body = {
-      token: refreshToken
+      access_token: accessToken,
+      refresh_token: refreshToken
     };
 
     return Authentication.request({ url, body })

--- a/src/api/ROSBridge/ROSBridge.ts
+++ b/src/api/ROSBridge/ROSBridge.ts
@@ -70,7 +70,7 @@ export class ROSBridge {
   getServices(): Promise<Array<string>> {
     this.connect();
     if (!this.ros.isConnected) {
-      return new Promise((_, reject) => reject(NOT_CONNECTED_ERROR));
+      return Promise.reject(NOT_CONNECTED_ERROR);
     }
     return new Promise((resolve, reject) => {
       this.ros.getServices(
@@ -90,7 +90,7 @@ export class ROSBridge {
   ): Promise<any> {
     this.connect();
     if (!this.ros.isConnected) {
-      return new Promise((_, reject) => reject(NOT_CONNECTED_ERROR));
+      return Promise.reject(NOT_CONNECTED_ERROR);
     }
     const service = new Service({ ros: this.ros, ...serviceID });
     const request = new ServiceRequest(message);


### PR DESCRIPTION
FP-1949 : Update Refresh token method

- Refresh token needs to pass access token and refresh token in post body