### PR TITLE
FP-2297: Redirect to login after losing token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.1.2
 
+- [FP-2297: Redirect to login after losing token](https://movai.atlassian.net/browse/FP-2297)
 - [FP-2049: Use Roles v2 endpoint](https://movai.atlassian.net/browse/FP-2049)
 - [FP-2202: Robot power off but online in the fleetboard alerts window](https://movai.atlassian.net/browse/FP-2202)
 - [FP-2233: De-activating alerts is not removing alerts in real-time](https://movai.atlassian.net/browse/FP-2233)

--- a/src/api/Database/WSSub.js
+++ b/src/api/Database/WSSub.js
@@ -35,7 +35,7 @@ class WSSub {
     this.RESEND_TIMEOUT = 1000;
     this.RETRIES = 3;
     this.NORMAL_CLOSE_EVT = 1000;
-
+    
     // supported commands
     this.commands = {
       SUBSCRIBE: "subscribe",
@@ -321,6 +321,10 @@ class WSSub {
     return connectionPromise;
   };
 
+  handleFalseConnection = (statusText) => {
+    if(statusText === "Token must be a string!") return Authentication.logout();
+  }
+
   /**
    * Check connection state by doing requests
    * @returns Heartbeat fetch promise
@@ -330,12 +334,14 @@ class WSSub {
       method: "POST",
       body: JSON.stringify({ token: getToken() })
     })
-      .then(_res => {
+      .then(res => {
+        if (!res.ok && res.status !== 200) return this.handleFalseConnection(res.statusText);
         if (this.connectionState === CONNECTION.online) return;
         this.connectionState = CONNECTION.online;
         this.onOnline();
       })
       .catch(_err => {
+        console.warn(_err);
         if (this.connectionState === CONNECTION.offline) return;
         this.connectionState = CONNECTION.offline;
         this.onOffline();


### PR DESCRIPTION
[FP-2297](https://movai.atlassian.net/browse/FP-2297)

* After losing the token-verify call (by passing other than a string as a token ie: remove cookies) we are now logging out the user.

[FP-2297]: https://movai.atlassian.net/browse/FP-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ