### PR TITLE
FP-2926: Fixed a couple of console errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # TBD
 
+- [FP-2926](https://movai.atlassian.net/browse/FP-2926): Clear console and app errors
 - [FP-2847](https://movai.atlassian.net/browse/FP-2847): Review and enable lib-core unit tests
 - [QAP-3942](https://movai.atlassian.net/browse/QAP-3942): Review devcontainer configuration for lib-core
 - [FP-2840](https://movai.atlassian.net/browse/FP-2840): Update ReadMe's on all apps

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "testStatic": "webpack --mode=development && echo 'Open browser at http://localhost:3030/test/index.html' && node test/server.js",
     "build": "webpack --mode=production",
     "buildDev": "webpack --mode=development --watch",
-    "clean": "rm -rf node_modules"
+    "clean": "rm -rf node_modules",
+    "ts": "tsc --noEmit"
   },
   "repository": {
     "type": "git",

--- a/src/api/Document/DocumentV1.js
+++ b/src/api/Document/DocumentV1.js
@@ -70,7 +70,7 @@ class DocumentV1 {
 
       return apiVersion === "v1" ? documentData : documentData[type][name];
     } catch (e) {
-      console.log(`Error reading document "${name}" of type "${type}"`, e);
+      console.error(`Error reading document "${name}" of type "${type}"`, e);
     }
   };
 

--- a/src/api/Document/DocumentV1.js
+++ b/src/api/Document/DocumentV1.js
@@ -58,15 +58,20 @@ class DocumentV1 {
   /**
    * Get document data
    */
-  read = (apiVersion = "v1") => {
+  read = async (apiVersion = "v1") => {
     const { type, name } = this;
     const path =
       apiVersion === "v1" ? `v1/${type}/${name}/` : `v2/db/${this.path}`;
 
-    return Rest.get({ path }).then(data => {
-      this.data = data;
-      return apiVersion === "v1" ? data : data[type][name];
-    });
+    try {
+      const documentData = await Rest.get({ path });
+
+      this.data = documentData;
+
+      return apiVersion === "v1" ? documentData : documentData[type][name];
+    } catch (e) {
+      console.log(`Error reading document "${name}" of type "${type}"`, e);
+    }
   };
 
   /**

--- a/src/api/Features/index.js
+++ b/src/api/Features/index.js
@@ -1,21 +1,41 @@
 import yaml from "js-yaml";
-import Document from "../Document/Document"
+import Document from "../Document/Document";
 let features = {};
 
-if (!window.mock)
-  Document.factory({ type: "Configuration", name: "ee" }).read().then(((val) => {
-    const json = yaml.load(val.Yaml);
-    if (json.Features?.length)
-      for (const key of json.Features)
-        features[key] = true;
-    console.log("EE: " + (json.Version ?? "2.4.0 (assumed)") + "\nFEATURES: " + Object.keys(features).join(","));
-  }));
+if (!window.mock) {
+  Document.factory({ type: "Configuration", name: "ee" })
+    .read()
+    .then(val => {
+      let json = {};
+
+      try {
+        json = yaml.load(val?.Yaml);
+        if (json.Features?.length)
+          for (const key of json.Features) features[key] = true;
+      } catch (e) {
+        console.log("Error fetching configuration", e);
+      }
+
+      console.log(
+        "EE: " +
+          (json.Version ?? "2.4.0 (assumed)") +
+          "\nFEATURES: " +
+          Object.keys(features).join(",")
+      );
+    });
+}
 
 const Features = {
   get: key => features[key],
-  set: key => { features[key] = value; },
-  enable: key => { features[key] = true; },
-  disable: key => { features[key] = false; },
+  set: key => {
+    features[key] = value;
+  },
+  enable: key => {
+    features[key] = true;
+  },
+  disable: key => {
+    features[key] = false;
+  }
 };
 
 export default Features;

--- a/src/api/RobotManager/RobotManager.ts
+++ b/src/api/RobotManager/RobotManager.ts
@@ -251,9 +251,9 @@ class RobotManager {
     clearTimeout(this.heartbeatTimeout);
     const robotsWhichChangedOnlineStatus = [];
     Object.values(this.robots).forEach(robot => {
-      const previousOnlineStatus = this.cachedRobots[robot.id].Online;
+      const previousOnlineStatus = this.cachedRobots[robot.id]?.Online;
       this.checkStatus(robot);
-      if (this.cachedRobots[robot.id].Online !== previousOnlineStatus) {
+      if (this.cachedRobots[robot.id]?.Online !== previousOnlineStatus) {
         robotsWhichChangedOnlineStatus.push(robot);
       }
     });
@@ -278,7 +278,9 @@ class RobotManager {
    */
   private checkStatus = (robot: ProtectedRobot) => {
     const id = robot.id;
-    this.cachedRobots[id].Online = robot.updateStatus();
+
+    if (this.cachedRobots[id])
+      this.cachedRobots[id].Online = robot.updateStatus();
   };
 
   /**
@@ -341,7 +343,9 @@ class RobotManager {
     const _message = getRequestMessage(queryParam?.searchMessage);
     const _dates = getRequestDate(queryParam?.date?.from, queryParam?.date?.to);
     const _robots = getRequestRobots(queryParam?.robot?.selected);
-    return [_limit, _levels, _services, _dates, _tags, _message, _robots].join("");
+    return [_limit, _levels, _services, _dates, _tags, _message, _robots].join(
+      ""
+    );
   }
 
   /**


### PR DESCRIPTION
Addresses [FP-2926](https://movai.atlassian.net/browse/FP-2926)

* Added a script to validate typescript
* Made document reading more resilient by showing a console.error instead of not catching the error and having that invasive backdrop with the error.
![image](https://github.com/user-attachments/assets/4a88771d-dd90-4b16-9c98-36a1e8fd566f)
* Made reading the configuration more resilient by showing a console.error if we can't read the configuration for some reason.
* Used optional chaining to prevent the Robot not Online error.
![image](https://github.com/user-attachments/assets/3caa7d05-313a-453c-a7c0-77f447e54236)


[FP-2926]: https://movai.atlassian.net/browse/FP-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ