### PR TITLE
FP-3061 + FP-2989

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # TBD
 
+- [FP-3061](https://movai.atlassian.net/browse/FP-3061): Release of mutex lock does not work
+- [FP-2989](https://movai.atlassian.net/browse/FP-2989): ADMIN BOARD - Unclear message to user creation failure
 - [FP-2916](https://movai.atlassian.net/browse/FP-2916): Configure husky, lint-staged and prettier for lib-core
 
 # 1.2.3

--- a/src/api/LockManager/LockManager.ts
+++ b/src/api/LockManager/LockManager.ts
@@ -120,7 +120,7 @@ class LockManager {
    * Execute DELETE request
    */
   delete = ({ lockName, robotId }: { lockName: string; robotId: string }) => {
-    const path = `v1/${lockName}/${robotId}/`;
+    const path = `v1/lock/${lockName}/`;
     return Rest.delete({ path });
   };
 

--- a/src/api/Rest/RestBase.js
+++ b/src/api/Rest/RestBase.js
@@ -34,7 +34,7 @@ RestBase.getUrl = ({ path, search = {} }) => {
  * @param {String} method - Request method
  * @param {Object} body - Request payload
  */
-RestBase._request = ({
+RestBase._request = async ({
   url,
   path,
   method = "GET",
@@ -53,12 +53,10 @@ RestBase._request = ({
 
   if (!skipBody.includes(method)) payload.body = JSON.stringify(body);
 
-  return fetch(requestUrl, payload).then((response) => {
-    if (!response.ok) {
-      return Promise.reject(response);
-    }
-    return response.json();
-  });
+  const response = await fetch(requestUrl, payload);
+
+  if (!response.ok) throw new Error(await response.text());
+  else return await response.json();
 };
 
 /**


### PR DESCRIPTION
- [FP-3061](https://movai.atlassian.net/browse/FP-3061): Release of mutex lock does not work
- [FP-2989](https://movai.atlassian.net/browse/FP-2989): ADMIN BOARD - Unclear message to user creation failure

This PR improves responses to failed Rest requests. Meaning, it throws an error with the text of the response.


[FP-3061]: https://movai.atlassian.net/browse/FP-3061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FP-2989]: https://movai.atlassian.net/browse/FP-2989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ